### PR TITLE
fix(INT-985): summary behavior bug

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,5 +7,13 @@
   "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "none",
-  "useTabs": false
+  "useTabs": false,
+  "overrides": [
+    {
+      "files": "*.hbs",
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
 }

--- a/components/block.js
+++ b/components/block.js
@@ -9,7 +9,6 @@ polarity.export = PolarityComponent.extend({
   showFilesReferring: false,
   showCopyMessage: false,
   showHistoricalWhois: false,
-  behaviorSummary: null,
   expandedWhoisMap: Ember.computed.alias('block.data.details.expandedWhoisMap'),
   communityScoreWidth: Ember.computed('details.reputation', function () {
     let reputation = this.get('details.reputation');

--- a/components/block.js
+++ b/components/block.js
@@ -123,18 +123,18 @@ polarity.export = PolarityComponent.extend({
   elementCircumference: Ember.computed('elementRadius', function () {
     return 2 * Math.PI * this.get('elementRadius');
   }),
-  _getStrokeOffset (ticScore, circumference) {
+  _getStrokeOffset(ticScore, circumference) {
     let progress = ticScore / this.details.total;
     return circumference * (1 - progress);
   },
-  _getThreatColor (ticScore) {
+  _getThreatColor(ticScore) {
     if (ticScore > 0) {
       return this.get('redThreat');
     } else {
       return this.get('greenThreat');
     }
   },
-  init () {
+  init() {
     this.set(
       'showScanResults',
       this.get('block.userOptions.showNoDetections') === false
@@ -307,7 +307,7 @@ polarity.export = PolarityComponent.extend({
       this.set(`expandedWhoisMap.${index}`, !this.get(`expandedWhoisMap.${index}`));
     }
   },
-  copyElementToClipboard (element) {
+  copyElementToClipboard(element) {
     window.getSelection().removeAllRanges();
     let range = document.createRange();
     range.selectNode(
@@ -317,14 +317,14 @@ polarity.export = PolarityComponent.extend({
     document.execCommand('copy');
     window.getSelection().removeAllRanges();
   },
-  getElementRange (element) {
+  getElementRange(element) {
     let range = document.createRange();
     range.selectNode(
       typeof element === 'string' ? document.getElementById(element) : element
     );
     return range;
   },
-  restoreCopyState (savedSettings) {
+  restoreCopyState(savedSettings) {
     const {
       activeTab,
       showFilesReferring,

--- a/components/block.js
+++ b/components/block.js
@@ -307,7 +307,7 @@ polarity.export = PolarityComponent.extend({
       this.set(`expandedWhoisMap.${index}`, !this.get(`expandedWhoisMap.${index}`));
     }
   },
-  copyElementToClipboard(element) {
+  copyElementToClipboard (element) {
     window.getSelection().removeAllRanges();
     let range = document.createRange();
     range.selectNode(
@@ -317,14 +317,14 @@ polarity.export = PolarityComponent.extend({
     document.execCommand('copy');
     window.getSelection().removeAllRanges();
   },
-  getElementRange(element) {
+  getElementRange (element) {
     let range = document.createRange();
     range.selectNode(
       typeof element === 'string' ? document.getElementById(element) : element
     );
     return range;
   },
-  restoreCopyState(savedSettings) {
+  restoreCopyState (savedSettings) {
     const {
       activeTab,
       showFilesReferring,

--- a/components/block.js
+++ b/components/block.js
@@ -7,6 +7,7 @@ polarity.export = PolarityComponent.extend({
   maxUrlsToShow: 20,
   showScanResults: false,
   showFilesReferring: false,
+  showCopyMessage: false,
   showHistoricalWhois: false,
   behaviorSummary: null,
   expandedWhoisMap: Ember.computed.alias('block.data.details.expandedWhoisMap'),
@@ -171,7 +172,6 @@ polarity.export = PolarityComponent.extend({
     this.set('block._state.loadingBehaviors', true);
     this.sendIntegrationMessage(payload)
       .then((behaviorSummary) => {
-        console.log('AAAAAAAAA', behaviorSummary);
         this.set('block.data.details.behaviorSummary', behaviorSummary);
         this.set(
           'showRegistryKeys',

--- a/components/block.js
+++ b/components/block.js
@@ -8,7 +8,7 @@ polarity.export = PolarityComponent.extend({
   showScanResults: false,
   showFilesReferring: false,
   showHistoricalWhois: false,
-  showCopyMessage: false,
+  behaviorSummary: null,
   expandedWhoisMap: Ember.computed.alias('block.data.details.expandedWhoisMap'),
   communityScoreWidth: Ember.computed('details.reputation', function () {
     let reputation = this.get('details.reputation');
@@ -123,18 +123,18 @@ polarity.export = PolarityComponent.extend({
   elementCircumference: Ember.computed('elementRadius', function () {
     return 2 * Math.PI * this.get('elementRadius');
   }),
-  _getStrokeOffset(ticScore, circumference) {
+  _getStrokeOffset (ticScore, circumference) {
     let progress = ticScore / this.details.total;
     return circumference * (1 - progress);
   },
-  _getThreatColor(ticScore) {
+  _getThreatColor (ticScore) {
     if (ticScore > 0) {
       return this.get('redThreat');
     } else {
       return this.get('greenThreat');
     }
   },
-  init() {
+  init () {
     this.set(
       'showScanResults',
       this.get('block.userOptions.showNoDetections') === false
@@ -171,6 +171,7 @@ polarity.export = PolarityComponent.extend({
     this.set('block._state.loadingBehaviors', true);
     this.sendIntegrationMessage(payload)
       .then((behaviorSummary) => {
+        console.log('AAAAAAAAA', behaviorSummary);
         this.set('block.data.details.behaviorSummary', behaviorSummary);
         this.set(
           'showRegistryKeys',

--- a/integration.js
+++ b/integration.js
@@ -59,7 +59,7 @@ const TYPES_BY_SHOW_NO_DETECTIONS = {
  * @param options
  * @param cb
  */
-function doLookup (entities, options, cb) {
+function doLookup(entities, options, cb) {
   // if the threshold rules are disabled then we want an empty rule set (empty array)
   if (options.baselineInvestigationThresholdEnabled === false) {
     compiledThresholdRules = [];
@@ -265,7 +265,7 @@ function doLookup (entities, options, cb) {
   );
 }
 
-function _isEntityBlocked (entity, options) {
+function _isEntityBlocked(entity, options) {
   const blocklist = options.blocklist;
   const currentIpBlocklistRegex = options.ipBlocklistRegex;
   const currentDomainUrlBlocklistRegex = options.domainUrlBlocklistRegex;
@@ -348,13 +348,13 @@ function _isEntityBlocked (entity, options) {
   return false;
 }
 
-function _removeFromThrottleCache (apiKey) {
+function _removeFromThrottleCache(apiKey) {
   return function () {
     throttleCache.delete(apiKey);
   };
 }
 
-function _handleRequestError (err, response, body, options, cb) {
+function _handleRequestError(err, response, body, options, cb) {
   if (err) {
     cb(
       _createJsonErrorPayload(
@@ -428,7 +428,7 @@ function _handleRequestError (err, response, body, options, cb) {
   cb(null, body);
 }
 
-function _lookupHash (hashesArray, entityLookup, options, done) {
+function _lookupHash(hashesArray, entityLookup, options, done) {
   if (doLookupLogging) {
     debugLookupStats.hashLookups++;
   }
@@ -469,7 +469,7 @@ function _lookupHash (hashesArray, entityLookup, options, done) {
   );
 }
 
-function _lookupUrl (entity, options, done) {
+function _lookupUrl(entity, options, done) {
   if (doLookupLogging) debugLookupStats.urlLookups++;
 
   const urlAsBase64WithoutPadding = Buffer.from(entity.value)
@@ -718,7 +718,7 @@ const getDetailFields = (detailFields, attributes) =>
     };
   }, detailFields);
 
-function _lookupEntityType (type, entity, options, done) {
+function _lookupEntityType(type, entity, options, done) {
   if (doLookupLogging) debugLookupStats[`${type}Lookups`]++;
 
   let requestOptions = {
@@ -753,7 +753,7 @@ function _lookupEntityType (type, entity, options, done) {
   });
 }
 
-function parseBaselineInvestigationThreshold (bti) {
+function parseBaselineInvestigationThreshold(bti) {
   const rules = bti.split(',');
   const compiledRules = [];
   rules.forEach((rule) => {
@@ -797,7 +797,7 @@ function parseBaselineInvestigationThreshold (bti) {
  * @param range
  * @returns {{min: number, max: number}}
  */
-function splitBtiRange (rule, range) {
+function splitBtiRange(rule, range) {
   let ranges = range.split('-');
   if (ranges.length !== 1 && ranges.length !== 2) {
     throw `Invalid range [${range}] on rule [${rule}].  Range must be a single number or a range of the format <number>-<number>`;
@@ -837,13 +837,13 @@ function splitBtiRange (rule, range) {
  * @returns {{errors: *[]}}
  * @private
  */
-function _createJsonErrorPayload (msg, pointer, httpCode, code, title, meta) {
+function _createJsonErrorPayload(msg, pointer, httpCode, code, title, meta) {
   return {
     errors: [_createJsonErrorObject(msg, pointer, httpCode, code, title, meta)]
   };
 }
 
-function _createJsonErrorObject (msg, pointer, httpCode, code, title, meta) {
+function _createJsonErrorObject(msg, pointer, httpCode, code, title, meta) {
   let error = {
     detail: msg,
     status: httpCode.toString(),
@@ -864,7 +864,7 @@ function _createJsonErrorObject (msg, pointer, httpCode, code, title, meta) {
   return error;
 }
 
-async function getWhois (entity, options) {
+async function getWhois(entity, options) {
   return new Promise((resolve, reject) => {
     if (entity.isIP || entity.isDomain) {
       const type = entity.isIP ? 'ip' : 'domain';
@@ -923,7 +923,7 @@ async function getWhois (entity, options) {
  * @param entity
  * @param options
  */
-async function getRelations (entity, options) {
+async function getRelations(entity, options) {
   return new Promise((resolve, reject) => {
     if (entity.isIP || entity.isDomain) {
       const type = entity.isIP ? 'ip' : 'domain';
@@ -1001,7 +1001,7 @@ async function getRelations (entity, options) {
   });
 }
 
-function getBehaviors (entity, options) {
+function getBehaviors(entity, options) {
   return new Promise((resolve, reject) => {
     if (entity.isMD5 || entity.isSHA1 || entity.isSHA256) {
       let behaviourSummaryOptions = {
@@ -1030,7 +1030,7 @@ function getBehaviors (entity, options) {
   });
 }
 
-function startup (logger) {
+function startup(logger) {
   Logger = logger;
 
   if (config && config.logging && config.logging.logLookupStats) {
@@ -1082,7 +1082,7 @@ function startup (logger) {
   requestWithDefaults = request.defaults(defaults);
 }
 
-function _logLookupStats () {
+function _logLookupStats() {
   debugLookupStats.ipCount = lookupIpSet.size;
   debugLookupStats.domainCount = lookupDomainSet.size;
   debugLookupStats.urlCount = lookupUrlSet.size;
@@ -1110,7 +1110,7 @@ function _logLookupStats () {
   }
 }
 
-function errorToPojo (err) {
+function errorToPojo(err) {
   if (err instanceof Error) {
     return {
       // Pull all enumerable properties, supporting properties on custom Errors
@@ -1125,7 +1125,7 @@ function errorToPojo (err) {
   return err;
 }
 
-async function onMessage (payload, options, cb) {
+async function onMessage(payload, options, cb) {
   const { entity, action } = payload;
   switch (action) {
     case 'GET_RELATIONS':
@@ -1158,7 +1158,7 @@ async function onMessage (payload, options, cb) {
   }
 }
 
-function validateOptions (userOptions, cb) {
+function validateOptions(userOptions, cb) {
   let errors = [];
   if (
     typeof userOptions.apiKey.value !== 'string' ||

--- a/integration.js
+++ b/integration.js
@@ -511,11 +511,11 @@ const _processLookupItem = (
   showEntitiesWithNoDetections,
   showNoInfoTag
 ) => {
-  if(result && result.__keyLimitReached){
+  if (result && result.__keyLimitReached) {
     return {
       entity,
       data: null
-    }
+    };
   }
 
   const data = fp.get('data', result);

--- a/integration.js
+++ b/integration.js
@@ -59,7 +59,7 @@ const TYPES_BY_SHOW_NO_DETECTIONS = {
  * @param options
  * @param cb
  */
-function doLookup(entities, options, cb) {
+function doLookup (entities, options, cb) {
   // if the threshold rules are disabled then we want an empty rule set (empty array)
   if (options.baselineInvestigationThresholdEnabled === false) {
     compiledThresholdRules = [];
@@ -265,7 +265,7 @@ function doLookup(entities, options, cb) {
   );
 }
 
-function _isEntityBlocked(entity, options) {
+function _isEntityBlocked (entity, options) {
   const blocklist = options.blocklist;
   const currentIpBlocklistRegex = options.ipBlocklistRegex;
   const currentDomainUrlBlocklistRegex = options.domainUrlBlocklistRegex;
@@ -348,13 +348,13 @@ function _isEntityBlocked(entity, options) {
   return false;
 }
 
-function _removeFromThrottleCache(apiKey) {
+function _removeFromThrottleCache (apiKey) {
   return function () {
     throttleCache.delete(apiKey);
   };
 }
 
-function _handleRequestError(err, response, body, options, cb) {
+function _handleRequestError (err, response, body, options, cb) {
   if (err) {
     cb(
       _createJsonErrorPayload(
@@ -428,7 +428,7 @@ function _handleRequestError(err, response, body, options, cb) {
   cb(null, body);
 }
 
-function _lookupHash(hashesArray, entityLookup, options, done) {
+function _lookupHash (hashesArray, entityLookup, options, done) {
   if (doLookupLogging) {
     debugLookupStats.hashLookups++;
   }
@@ -469,7 +469,7 @@ function _lookupHash(hashesArray, entityLookup, options, done) {
   );
 }
 
-function _lookupUrl(entity, options, done) {
+function _lookupUrl (entity, options, done) {
   if (doLookupLogging) debugLookupStats.urlLookups++;
 
   const urlAsBase64WithoutPadding = Buffer.from(entity.value)
@@ -718,7 +718,7 @@ const getDetailFields = (detailFields, attributes) =>
     };
   }, detailFields);
 
-function _lookupEntityType(type, entity, options, done) {
+function _lookupEntityType (type, entity, options, done) {
   if (doLookupLogging) debugLookupStats[`${type}Lookups`]++;
 
   let requestOptions = {
@@ -753,7 +753,7 @@ function _lookupEntityType(type, entity, options, done) {
   });
 }
 
-function parseBaselineInvestigationThreshold(bti) {
+function parseBaselineInvestigationThreshold (bti) {
   const rules = bti.split(',');
   const compiledRules = [];
   rules.forEach((rule) => {
@@ -797,7 +797,7 @@ function parseBaselineInvestigationThreshold(bti) {
  * @param range
  * @returns {{min: number, max: number}}
  */
-function splitBtiRange(rule, range) {
+function splitBtiRange (rule, range) {
   let ranges = range.split('-');
   if (ranges.length !== 1 && ranges.length !== 2) {
     throw `Invalid range [${range}] on rule [${rule}].  Range must be a single number or a range of the format <number>-<number>`;
@@ -837,13 +837,13 @@ function splitBtiRange(rule, range) {
  * @returns {{errors: *[]}}
  * @private
  */
-function _createJsonErrorPayload(msg, pointer, httpCode, code, title, meta) {
+function _createJsonErrorPayload (msg, pointer, httpCode, code, title, meta) {
   return {
     errors: [_createJsonErrorObject(msg, pointer, httpCode, code, title, meta)]
   };
 }
 
-function _createJsonErrorObject(msg, pointer, httpCode, code, title, meta) {
+function _createJsonErrorObject (msg, pointer, httpCode, code, title, meta) {
   let error = {
     detail: msg,
     status: httpCode.toString(),
@@ -864,7 +864,7 @@ function _createJsonErrorObject(msg, pointer, httpCode, code, title, meta) {
   return error;
 }
 
-async function getWhois(entity, options) {
+async function getWhois (entity, options) {
   return new Promise((resolve, reject) => {
     if (entity.isIP || entity.isDomain) {
       const type = entity.isIP ? 'ip' : 'domain';
@@ -923,7 +923,7 @@ async function getWhois(entity, options) {
  * @param entity
  * @param options
  */
-async function getRelations(entity, options) {
+async function getRelations (entity, options) {
   return new Promise((resolve, reject) => {
     if (entity.isIP || entity.isDomain) {
       const type = entity.isIP ? 'ip' : 'domain';
@@ -1001,7 +1001,7 @@ async function getRelations(entity, options) {
   });
 }
 
-function getBehaviors(entity, options) {
+function getBehaviors (entity, options) {
   return new Promise((resolve, reject) => {
     if (entity.isMD5 || entity.isSHA1 || entity.isSHA256) {
       let behaviourSummaryOptions = {
@@ -1017,7 +1017,11 @@ function getBehaviors(entity, options) {
             return reject(err);
           }
 
-          resolve(result.data);
+          if (result.data) {
+            resolve(result.data);
+          } else {
+            resolve([]);
+          }
         });
       });
     } else {
@@ -1026,7 +1030,7 @@ function getBehaviors(entity, options) {
   });
 }
 
-function startup(logger) {
+function startup (logger) {
   Logger = logger;
 
   if (config && config.logging && config.logging.logLookupStats) {
@@ -1078,7 +1082,7 @@ function startup(logger) {
   requestWithDefaults = request.defaults(defaults);
 }
 
-function _logLookupStats() {
+function _logLookupStats () {
   debugLookupStats.ipCount = lookupIpSet.size;
   debugLookupStats.domainCount = lookupDomainSet.size;
   debugLookupStats.urlCount = lookupUrlSet.size;
@@ -1106,7 +1110,7 @@ function _logLookupStats() {
   }
 }
 
-function errorToPojo(err) {
+function errorToPojo (err) {
   if (err instanceof Error) {
     return {
       // Pull all enumerable properties, supporting properties on custom Errors
@@ -1121,7 +1125,7 @@ function errorToPojo(err) {
   return err;
 }
 
-async function onMessage(payload, options, cb) {
+async function onMessage (payload, options, cb) {
   const { entity, action } = payload;
   switch (action) {
     case 'GET_RELATIONS':
@@ -1154,7 +1158,7 @@ async function onMessage(payload, options, cb) {
   }
 }
 
-function validateOptions(userOptions, cb) {
+function validateOptions (userOptions, cb) {
   let errors = [];
   if (
     typeof userOptions.apiKey.value !== 'string' ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "VirusTotal",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "VirusTotal",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "main": "./integration.js",
   "private": true,
   "dependencies": {

--- a/templates/block.hbs
+++ b/templates/block.hbs
@@ -22,45 +22,45 @@
 
 {{#if details.noInfoMessage}}
   <div>
-    <span class='p-key'><em>No Information in VirusTotal</em></span>
+    <span class="p-key"><em>No Information in VirusTotal</em></span>
   </div>
 {{else}}
-  <div class='top-section'>
-    <div class='indicator'>
-      <div class='tic-gauge-container'>
-        <svg x='0' y='0' width='100%' height='100%' viewBox='0 0 55 50'>
-          <g transform='translate(28,25)'>
+  <div class="top-section">
+    <div class="indicator">
+      <div class="tic-gauge-container">
+        <svg x="0" y="0" width="100%" height="100%" viewBox="0 0 55 50">
+          <g transform="translate(28,25)">
             <g>
               <circle
-                r='{{elementRadius}}'
-                stroke='#eee'
-                transform='rotate(-90)'
-                fill='#fff'
-                stroke-width='{{elementStrokeWidth}}'
-                cx='0'
-                cy='0'
+                r="{{elementRadius}}"
+                stroke="#eee"
+                transform="rotate(-90)"
+                fill="#fff"
+                stroke-width="{{elementStrokeWidth}}"
+                cx="0"
+                cy="0"
               ></circle>
               <circle
-                stroke-dasharray='{{elementCircumference}}'
-                r='{{elementRadius}}'
-                stroke='{{elementColor}}'
-                transform='rotate(-90)'
-                fill='none'
-                stroke-dashoffset='{{elementStrokeOffset}}'
-                stroke-width='{{elementStrokeWidth}}'
-                cx='0'
-                cy='0'
+                stroke-dasharray="{{elementCircumference}}"
+                r="{{elementRadius}}"
+                stroke="{{elementColor}}"
+                transform="rotate(-90)"
+                fill="none"
+                stroke-dashoffset="{{elementStrokeOffset}}"
+                stroke-width="{{elementStrokeWidth}}"
+                cx="0"
+                cy="0"
               ></circle>
               <text
-                text-anchor='middle'
-                x='0'
-                y='0'
-                fill='{{elementColor}}'
-                font-size='13'
+                text-anchor="middle"
+                x="0"
+                y="0"
+                fill="{{elementColor}}"
+                font-size="13"
               >
                 {{details.positives}}
               </text>
-              <text text-anchor='middle' x='-1' y='10' fill='gray' font-size='7'>
+              <text text-anchor="middle" x="-1" y="10" fill="gray" font-size="7">
                 /
                 {{details.total}}
               </text>
@@ -76,20 +76,21 @@
             size="2x"
             icon=communityScoreIcon
             fixedWidth=true
-            class=communityScoreColorClass}}
+            class=communityScoreColorClass
+          }}
         </div>
         <div class="score-line"></div>
         <div class="p-footnote score-footer">Community Score ({{details.reputation}})</div>
       </div>
       {{#if details.tags.length}}
-        <div class='tags-container'>
-          <h1 class='p-title'>
-            {{fa-icon 'tags' fixedWidth=true}}
+        <div class="tags-container">
+          <h1 class="p-title">
+            {{fa-icon "tags" fixedWidth=true}}
             Tags
           </h1>
-          <div class='tags'>
+          <div class="tags">
             {{#each details.tags as |tag|}}
-              <div class='tag'>
+              <div class="tag">
                 {{tag}}
               </div>
             {{/each}}
@@ -99,44 +100,44 @@
     </div>
   </div>
 
-  <ul class='nav nav-tabs mt-2'>
-    <li class='nav-item'>
+  <ul class="nav nav-tabs mt-2">
+    <li class="nav-item">
       <a
-        {{action 'changeTab' 'detection'}}
-        class='nav-link {{if (or (eq activeTab "detection") (not activeTab)) "active"}}'
-        href='#'
+        {{action "changeTab" "detection"}}
+        class="nav-link {{if (or (eq activeTab 'detection') (not activeTab)) 'active'}}"
+        href="#"
       >
         Detection
       </a>
     </li>
     {{#if details.detailsTab.length}}
-      <li class='nav-item'>
+      <li class="nav-item">
         <a
-          {{action 'changeTab' 'details'}}
-          class='nav-link {{if (or (eq activeTab "details") (not activeTab)) "active"}}'
-          href='#'
+          {{action "changeTab" "details"}}
+          class="nav-link {{if (or (eq activeTab 'details') (not activeTab)) 'active'}}"
+          href="#"
         >
           Details
         </a>
       </li>
     {{/if}}
     {{#if (or block.entity.isIP block.entity.isDomain)}}
-      <li class='nav-item'>
+      <li class="nav-item">
         <a
-          {{action 'changeTab' 'relations'}}
-          class='nav-link {{if (eq activeTab "relations") "active"}}'
-          href='#'
+          {{action "changeTab" "relations"}}
+          class="nav-link {{if (eq activeTab 'relations') 'active'}}"
+          href="#"
         >
           Relations
         </a>
       </li>
     {{/if}}
     {{#if (or block.entity.isMD5 block.entity.isSHA1 block.entity.isSHA256)}}
-      <li class='nav-item'>
+      <li class="nav-item">
         <a
-          {{action 'changeTab' 'behaviorSummary'}}
-          class='nav-link {{if (eq activeTab "behaviorSummary") "active"}}'
-          href='#'
+          {{action "changeTab" "behaviorSummary"}}
+          class="nav-link {{if (eq activeTab 'behaviorSummary') 'active'}}"
+          href="#"
         >
           Behavior Summary
         </a>
@@ -146,71 +147,89 @@
   <div id="{{concat "virustotal-container-" uniqueIdPrefix}}" class="export-node">
     {{#if (eq activeTab 'detection')}}
 
-        <div class='p-link mt-2'>
-          <a href='{{details.detectionsLink}}'>View detections in VirusTotal
-            {{fa-icon 'external-link-square' class='external-link-icon'}}</a>
-        </div>
-        <h1 class="p-title">{{fa-icon "clipboard" fixedWidth=true}} Summary</h1>
-        <div>
-          <strong>{{details.positiveScans.length}}</strong> security vendor{{#if (not-eq details.positiveScans.length 1)}}s{{/if}} flagged this indicator as malicious.  The indicator has a
-          community score of <strong>{{details.reputation}}</strong> and was last scanned <strong>{{moment-from-now details.scan_date timeZone=timezone}}</strong>
-          on {{moment-format details.scan_date 'YYYY-MM-DD HH:mm:ss z' timeZone=timezone}}.
-          A negative community score indicates maliciousness, whereas a positive score reflects harmlessness where the higher the absolute number the more you may trust the score (-100 to 100).
-        </div>
-        {{! detections }}
-        <div class='toggle-header'>
-          <span class='p-action' {{action 'toggleShowResults' 'showScanResults'}}>
-            {{fa-icon 'laptop' fixedWidth=true}}
-            {{#unless block.userOptions.showNoDetections}}Positive {{/unless}}
-            Detections ({{details.positives}}
-            of
-            {{details.total}})
-            {{fa-icon (if showScanResults 'caret-up' 'caret-down') fixedWidth=true}}
-          </span>
-        </div>
-        {{#if showScanResults}}
-          <div class='scan-results'>
-            {{#unless details.positiveScans}}
-              <span>No security vendor flagged this indicator as malicious</span>
-            {{/unless}}
-            <table>
-              <tbody>
-                {{#each details.positiveScans as |positiveScan|}}
-                  <tr>
-                    <td>
-                      <span class='p-key'>{{positiveScan.name}} </span>
-                    </td>
-                    <td>
-                      <span class='p-value' style='color: #FF3A59'>
-                        {{fa-icon 'exclamation' class='p-red table-icon' fixedWidth=true}}
-                        {{positiveScan.result}}
-                      </span>
-                    </td>
-                  </tr>
-                {{/each}}
-                {{#if block.userOptions.showNoDetections}}
-                  {{#each details.negativeScans as |negativeScan|}}
-                    <tr>
-                      <td>
-                        <span class='p-key'>{{negativeScan.name}} </span>
-                      </td>
-                      <td>
-                        <span class='p-value'>
-                          {{#if (eq negativeScan.result 'Unrated')}}
-                            {{fa-icon 'question' class='p-grey table-icon' fixedWidth=true}}
+  {{#if (eq activeTab "detection")}}
+    <div class="p-link mt-2">
+      <a href="{{details.detectionsLink}}">View detections in VirusTotal
+        {{fa-icon "external-link-square" class="external-link-icon"}}</a>
+    </div>
+    <h1 class="p-title">{{fa-icon "clipboard" fixedWidth=true}} Summary</h1>
+    <div>
+      <strong>{{details.positiveScans.length}}</strong>
+      security vendor{{#if (not-eq details.positiveScans.length 1)}}s{{/if}}
+      flagged this indicator as malicious. The indicator has a community score of
+      <strong>{{details.reputation}}</strong>
+      and was last scanned
+      <strong>{{moment-from-now details.scan_date timeZone=timezone}}</strong>
+      on
+      {{moment-format details.scan_date "YYYY-MM-DD HH:mm:ss z" timeZone=timezone}}. A
+      negative community score indicates maliciousness, whereas a positive score reflects
+      harmlessness where the higher the absolute number the more you may trust the score
+      (-100 to 100).
+    </div>
+    {{! detections }}
+    <div class="toggle-header">
+      <span class="p-action" {{action "toggleShowResults" "showScanResults"}}>
+        {{fa-icon "laptop" fixedWidth=true}}
+        {{#unless block.userOptions.showNoDetections}}Positive {{/unless}}
+        Detections ({{details.positives}}
+        of
+        {{details.total}})
+        {{fa-icon (if showScanResults "caret-up" "caret-down") fixedWidth=true}}
+      </span>
+    </div>
+    {{#if showScanResults}}
+      <div class="scan-results">
+        {{#unless details.positiveScans}}
+          <span>No security vendor flagged this indicator as malicious</span>
+        {{/unless}}
+        <table>
+          <tbody>
+            {{#each details.positiveScans as |positiveScan|}}
+              <tr>
+                <td>
+                  <span class="p-key">{{positiveScan.name}} </span>
+                </td>
+                <td>
+                  <span class="p-value" style="color: #FF3A59">
+                    {{fa-icon "exclamation" class="p-red table-icon" fixedWidth=true}}
+                    {{positiveScan.result}}
+                  </span>
+                </td>
+              </tr>
+            {{/each}}
+            {{#if block.userOptions.showNoDetections}}
+              {{#each details.negativeScans as |negativeScan|}}
+                <tr>
+                  <td>
+                    <span class="p-key">{{negativeScan.name}} </span>
+                  </td>
+                  <td>
+                    <span class="p-value">
+                      {{#if (eq negativeScan.result "Unrated")}}
+                        {{fa-icon "question" class="p-grey table-icon" fixedWidth=true}}
+                      {{else}}
+                        {{#if (eq negativeScan.result "type-unsupported")}}
+                          {{fa-icon
+                            "eye-slash"
+                            class="p-grey table-icon"
+                            fixedWidth=true
+                          }}
+                        {{else}}
+                          {{#if (eq negativeScan.result "Suspicious")}}
+                            {{fa-icon "info" class="p-orange table-icon" fixedWidth=true}}
                           {{else}}
-                            {{#if (eq negativeScan.result 'type-unsupported')}}
-                              {{fa-icon 'eye-slash' class='p-grey table-icon' fixedWidth=true}}
-                            {{else}}
-                              {{#if (eq negativeScan.result 'Suspicious')}}
-                                {{fa-icon 'info' class='p-orange table-icon' fixedWidth=true}}
-                              {{else}}
-                                {{fa-icon 'check' class='p-green table-icon' fixedWidth=true}}
-                              {{/if}}
-                            {{/if}}
+                            {{fa-icon "check" class="p-green table-icon" fixedWidth=true}}
                           {{/if}}
-                          {{#if (eq negativeScan.result 'type-unsupported')}}
-                            <span class='p-grey'>Unable to process file type</span>
+                        {{/if}}
+                      {{/if}}
+                      {{#if (eq negativeScan.result "type-unsupported")}}
+                        <span class="p-grey">Unable to process file type</span>
+                      {{else}}
+                        {{#if (eq negativeScan.result "Suspicious")}}
+                          <span class="p-orange">Suspicious</span>
+                        {{else}}
+                          {{#if (not negativeScan.result)}}
+                            Undetected
                           {{else}}
                             {{#if (eq negativeScan.result 'Suspicious')}}
                               <span class='p-orange'>Suspicious</span>
@@ -234,104 +253,66 @@
     {{/if}}
     {{! end of detections}}
 
-    {{#if (eq activeTab 'details')}}
-      <div class='p-link mt-2'>
-        <a href='{{details.detailsLink}}'>View Details in VirusTotal
-          {{fa-icon 'external-link-square' class='external-link-icon'}}</a>
-      </div>
-      <div class='p-link mt-2'>
-        <a href='{{details.communityLink}}'>View Comments in VirusTotal
-          {{fa-icon 'external-link-square' class='external-link-icon'}}</a>
-      </div>
-      {{#if details.detailsTab.length}}
-        {{#each details.detailsTab as |detailsField|}}
-          {{#if detailsField.isObject}}
-            <h1 class='p-title'>{{fa-icon icon='th-list' fixedWidth=true}}
-              {{detailsField.key}}</h1>
-            {{#each-in detailsField.value as |key value|}}
-              {{#if value}}
-                <div>
-                  <span class='p-key'>{{key}}:</span>
-                  <span class='p-value'>{{value}}</span>
-                </div>
-              {{/if}}
-            {{/each-in}}
-          {{else if detailsField.isList}}
-              {{#each detailsField.value as |value|}}
-                {{#if value}}
-                  <div>
-                    <span class='p-key'>{{detailsField.key}}:</span>
-                    <span class='p-value'>{{value}}</span>
-                  </div>
-                {{/if}}
-              {{/each}}
-          {{else if detailsField.isTitle}}
-              <h1 class='p-title'>{{fa-icon icon='th-list' fixedWidth=true}}
-                {{detailsField.key}}</h1>
-          {{else if detailsField.isDate}}
+  {{#if (eq activeTab "details")}}
+    <div class="p-link mt-2">
+      <a href="{{details.detailsLink}}">View Details in VirusTotal
+        {{fa-icon "external-link-square" class="external-link-icon"}}</a>
+    </div>
+    <div class="p-link mt-2">
+      <a href="{{details.communityLink}}">View Comments in VirusTotal
+        {{fa-icon "external-link-square" class="external-link-icon"}}</a>
+    </div>
+    {{#if details.detailsTab.length}}
+      {{#each details.detailsTab as |detailsField|}}
+        {{#if detailsField.isObject}}
+          <h1 class="p-title">{{fa-icon icon="th-list" fixedWidth=true}}
+            {{detailsField.key}}</h1>
+          {{#each-in detailsField.value as |key value|}}
+            {{#if value}}
+              <div>
+                <span class="p-key">{{key}}:</span>
+                <span class="p-value">{{value}}</span>
+              </div>
+            {{/if}}
+          {{/each-in}}
+        {{else if detailsField.isList}}
+          {{#each detailsField.value as |value|}}
+            {{#if value}}
+              <div>
+                <span class="p-key">{{detailsField.key}}:</span>
+                <span class="p-value">{{value}}</span>
+              </div>
+            {{/if}}
+          {{/each}}
+        {{else if detailsField.isTitle}}
+          <h1 class="p-title">{{fa-icon icon="th-list" fixedWidth=true}}
+            {{detailsField.key}}</h1>
+        {{else if detailsField.isDate}}
+          <div>
+            <span class="p-key">{{detailsField.key}}:</span>
+            <span class="p-value">{{moment-format
+                (unix detailsField.value)
+                "YYYY-MM-DD HH:mm:ss z"
+                timeZone=timezone
+              }}</span>
+          </div>
+        {{else}}
+          {{#if detailsField.value}}
             <div>
-              <span class='p-key'>{{detailsField.key}}:</span>
-              <span class='p-value'>{{moment-format (unix detailsField.value) "YYYY-MM-DD HH:mm:ss z" timeZone=timezone}}</span>
+              <span class="p-key">{{detailsField.key}}:</span>
+              <span class="p-value">{{detailsField.value}}</span>
             </div>
-          {{else}}
-              {{#if detailsField.value}}
-                <div>
-                  <span class='p-key'>{{detailsField.key}}:</span>
-                  <span class='p-value'>{{detailsField.value}}</span>
-                </div>
-              {{/if}}
-          {{/if}}
-        {{/each}}
-      {{/if}}
-
-      {{#if (or block.entity.isMD5 block.entity.isSHA1 block.entity.isSHA256)}}
-        <div class='toggle-header'>
-          <span class='p-action' {{action 'toggleShowResults' 'block._state.showNames'}}>
-            {{fa-icon icon="file" fixedWidth=true}}
-            Names ({{details.names.length}})
-            {{fa-icon (if showFilesReferring 'caret-up' 'caret-down') fixedWidth=true}}
-          </span>
-        </div>
-        {{#if block._state.showNames}}
-          {{#if (gt details.names.length 0)}}
-            <div class="scrollable-block">
-              <table>
-                <tbody>
-                  {{#each details.names as |name index|}}
-                    <tr><td>{{name}}</td></tr>
-                  {{/each}}
-                </tbody>
-              </table>
-            </div>
-          {{else}}
-            <span>No Filenames found</span>
           {{/if}}
         {{/if}}
       {{/if}}
     {{/if}}
 
-    {{! start of behavior summary}}
-    {{#if (eq activeTab 'behaviorSummary')}}
-      <div class='p-link mt-2'>
-        <a href='{{details.behaviorLink}}'>View behaviors in VirusTotal
-          {{fa-icon 'external-link-square' class='external-link-icon'}}</a>
-      </div>
-
-      {{#if block._state.errorBehaviors}}
-        <div class="alert alert-danger mt-2">
-          <pre>{{block._state.errorBehaviors}}</pre>
-        </div>`
-      {{/if}}
-
-      <div class='toggle-header'>
-        <span class='p-action' {{action 'toggleShowResults' 'showRegistryKeys'}}>
-          {{fa-icon 'key' fixedWidth=true}}
-          {{#if block._state.loadingBehaviors}}
-            {{fa-icon icon="spinner-third" spin=true fixedWidth=true}} Loading registry keys ...
-          {{else}}
-            Registry Keys ({{if details.behaviorSummary.registry_keys_opened details.behaviorSummary.registry_keys_opened.length "0"}})
-          {{/if}}
-          {{fa-icon (if showRegistryKeys 'caret-up' 'caret-down') fixedWidth=true}}
+    {{#if (or block.entity.isMD5 block.entity.isSHA1 block.entity.isSHA256)}}
+      <div class="toggle-header">
+        <span class="p-action" {{action "toggleShowResults" "block._state.showNames"}}>
+          {{fa-icon icon="file" fixedWidth=true}}
+          Names ({{details.names.length}})
+          {{fa-icon (if showFilesReferring "caret-up" "caret-down") fixedWidth=true}}
         </span>
       </div>
 
@@ -350,18 +331,39 @@
           <span>No registry key information available</span>
         {{/if}}
       {{/if}}
+    {{/if}}
+  {{/if}}
 
-      <div class="toggle-header">
-        <span class='p-action' {{action 'toggleShowResults' 'showFilesOpened'}}>
-          {{fa-icon 'file' fixedWidth=true}}
-          {{#if block._state.loadingBehaviors}}
-            {{fa-icon icon="spinner-third" spin=true fixedWidth=true}} Loading opened files ...
-          {{else}}
-            Opened Files ({{if details.behaviorSummary.files_opened details.behaviorSummary.files_opened.length "0"}})
-          {{/if}}
-          {{fa-icon (if showFilesOpened 'caret-up' 'caret-down') fixedWidth=true}}
-        </span>
-      </div>
+  {{! start of behavior summary}}
+  {{#if (eq activeTab "behaviorSummary")}}
+
+    <div class="p-link mt-2">
+      <a href="{{details.behaviorLink}}">View behaviors in VirusTotal
+        {{fa-icon "external-link-square" class="external-link-icon"}}</a>
+    </div>
+
+    {{#if block._state.errorBehaviors}}
+      <div class="alert alert-danger mt-2">
+        <pre>{{block._state.errorBehaviors}}</pre>
+      </div>`
+    {{/if}}
+
+    <div class="toggle-header">
+      <span class="p-action" {{action "toggleShowResults" "showRegistryKeys"}}>
+        {{fa-icon "key" fixedWidth=true}}
+        {{#if block._state.loadingBehaviors}}
+          {{fa-icon icon="spinner-third" spin=true fixedWidth=true}}
+          Loading registry keys ...
+        {{else}}
+          Registry Keys ({{if
+            details.behaviorSummary.registry_keys_opened
+            details.behaviorSummary.registry_keys_opened.length
+            "0"
+          }})
+        {{/if}}
+        {{fa-icon (if showRegistryKeys "caret-up" "caret-down") fixedWidth=true}}
+      </span>
+    </div>
 
       {{#if showFilesOpened}}
         {{#if details.behaviorSummary.files_opened}}
@@ -371,121 +373,169 @@
               {{#each details.behaviorSummary.files_opened as |file|}}
                 <tr><td>{{file}}</td></tr>
               {{/each}}
-              </tbody>
-            </table>
-          </div>
-        {{else}}
-          <span>No opened files information available</span>
-        {{/if}}
+            </tbody>
+          </table>
+        </div>
+      {{else}}
+        <span>No registry key information available</span>
       {{/if}}
+    {{/if}}
 
+    <div class="toggle-header">
+      <span class="p-action" {{action "toggleShowResults" "showFilesOpened"}}>
+        {{fa-icon "file" fixedWidth=true}}
+        {{#if block._state.loadingBehaviors}}
+          {{fa-icon icon="spinner-third" spin=true fixedWidth=true}}
+          Loading opened files ...
+        {{else}}
+          Opened Files ({{if
+            details.behaviorSummary.files_opened
+            details.behaviorSummary.files_opened.length
+            "0"
+          }})
+        {{/if}}
+        {{fa-icon (if showFilesOpened "caret-up" "caret-down") fixedWidth=true}}
+      </span>
+    </div>
+
+    {{#if showFilesOpened}}
+      {{#if details.behaviorSummary.files_opened}}
+        <div class="scrollable-block">
+          <table>
+            <tbody>
+              {{#each details.behaviorSummary.files_opened as |file|}}
+                <tr><td>{{file}}</td></tr>
+              {{/each}}
+            </tbody>
+          </table>
+        </div>
+      {{else}}
+        <span>No opened files information available</span>
+      {{/if}}
+    {{/if}}
+  {{/if}}
+  {{! end of behavior summary}}
+
+  {{! START RELATIONS TAB }}
+  {{#if (eq activeTab "relations")}}
+    <div class="p-link mt-2">
+      <a href="{{details.relationsLink}}">View relations in VirusTotal
+        {{fa-icon "external-link-square" class="external-link-icon"}}</a>
+    </div>
+
+    {{#if block._state.errorWhois}}
+      <div class="alert alert-danger mt-2">
+        <pre>{{block._state.errorWhois}}</pre>
+      </div>`
     {{/if}}
     {{! end of behavior summary}}
 
 
-    {{! START RELATIONS TAB }}
-    {{#if (eq activeTab 'relations')}}
-      <div class='p-link mt-2'>
-        <a href='{{details.relationsLink}}'>View relations in VirusTotal
-          {{fa-icon 'external-link-square' class='external-link-icon'}}</a>
-      </div>
-
-      {{#if block._state.errorWhois}}
-        <div class="alert alert-danger mt-2">
-          <pre>{{block._state.errorWhois}}</pre>
-        </div>`
-      {{/if}}
-
-      {{#if block._state.errorRelations}}
-        <div class="alert alert-danger mt-2">
-          <pre>{{block._state.errorRelations}}</pre>
-        </div>`
-      {{/if}}
-
-      <div class='toggle-header'>
-        <span class='p-action' {{action 'toggleShowResults' 'showFilesReferring'}}>
-          {{fa-icon 'project-diagram' fixedWidth=true}}
-          {{#if block._state.loadingRelations}}
-            {{fa-icon icon="spinner-third" spin=true fixedWidth=true}} Loading files referring ...
-          {{else}}
-            Files Referring ({{details.referenceFiles.length}})
-          {{/if}}
-          {{fa-icon (if showFilesReferring 'caret-up' 'caret-down') fixedWidth=true}}
-        </span>
-      </div>
-
-      {{#if showFilesReferring}}
-        {{#if (eq details.referenceFiles.length 0)}}
-          <span>No files referring available</span>
+    <div class="toggle-header">
+      <span class="p-action" {{action "toggleShowResults" "showFilesReferring"}}>
+        {{fa-icon "project-diagram" fixedWidth=true}}
+        {{#if block._state.loadingRelations}}
+          {{fa-icon icon="spinner-third" spin=true fixedWidth=true}}
+          Loading files referring ...
         {{else}}
-          <div class="scrollable-block">
-            <table>
-              <tbody>
-              {{#each details.referenceFiles as |referrenceFile|}}
-              <tr>
-                <td class="pr-3">
-                  {{#if referrenceFile.name}}
-                    <div>
-                      <span class='p-key'>Name:</span>
-                      <span class='p-value'>
-                        {{#if referrenceFile.link}}
-                          <a href={{referrenceFile.link}}>{{referrenceFile.name}} {{fa-icon 'external-link-square' class='external-link-icon'}}</a>
-                        {{else}}
-                          {{referrenceFile.name}}
-                        {{/if}}
-                      </span>
-                    </div>
-                  {{/if}}
-                  {{#if referrenceFile.type}}
-                    <div>
-                      <span class='p-key'>Type:</span>
-                      <span class='p-value'>{{referrenceFile.type}}</span>
-                    </div>
-                  {{/if}}
-                  {{#if referrenceFile.detections}}
-                    <div>
-                      <span class='p-key'>Detections:</span>
-                      <span class='p-value'>{{referrenceFile.detections}}</span>
-                    </div>
-                  {{/if}}
-                  {{#if referrenceFile.scannedDate}}
-                    <div>
-                      <span class='p-key'>Scanned:</span>
-                      <span class='p-value'>
-                        {{#if (eq referrenceFile.scannedDate '-')}}
-                          -
-                        {{else}}
-                          {{moment-format referrenceFile.scannedDate 'YYYY-MM-DD HH:mm:ss UTC'}}
-                        {{/if}}
-                      </span>
-                    </div>
-                  {{/if}}
-                </td>
-              </tr>
-            {{/each}}
-              </tbody>
-            </table>
-          </div>
+          Files Referring ({{details.referenceFiles.length}})
         {{/if}}
+        {{fa-icon (if showFilesReferring "caret-up" "caret-down") fixedWidth=true}}
+      </span>
+    </div>
+
+    {{#if showFilesReferring}}
+      {{#if (eq details.referenceFiles.length 0)}}
+        <span>No files referring available</span>
+      {{else}}
+        <button
+          type="button"
+          title="Copy referring file names"
+          class="btn-sm naked file-copy-button"
+          {{action "copyReferringFiles"}}
+        >
+          {{fa-icon
+            icon="copy"
+            fixedWidth=true
+            class="copy-button-icon"
+            title="Copy referring file names"
+          }}
+        </button>
+
+        <div class="scrollable-block">
+          <table>
+            <tbody>
+              {{#each details.referenceFiles as |referrenceFile|}}
+                <tr>
+                  <td class="pr-3">
+                    {{#if referrenceFile.name}}
+                      <div>
+                        <span class="p-key">Name:</span>
+                        <span class="p-value">
+                          {{#if referrenceFile.link}}
+                            <a href={{referrenceFile.link}}>{{referrenceFile.name}}
+                              {{fa-icon
+                                "external-link-square"
+                                class="external-link-icon"
+                              }}</a>
+                          {{else}}
+                            {{referrenceFile.name}}
+                          {{/if}}
+                        </span>
+                      </div>
+                    {{/if}}
+                    {{#if referrenceFile.type}}
+                      <div>
+                        <span class="p-key">Type:</span>
+                        <span class="p-value">{{referrenceFile.type}}</span>
+                      </div>
+                    {{/if}}
+                    {{#if referrenceFile.detections}}
+                      <div>
+                        <span class="p-key">Detections:</span>
+                        <span class="p-value">{{referrenceFile.detections}}</span>
+                      </div>
+                    {{/if}}
+                    {{#if referrenceFile.scannedDate}}
+                      <div>
+                        <span class="p-key">Scanned:</span>
+                        <span class="p-value">
+                          {{#if (eq referrenceFile.scannedDate "-")}}
+                            -
+                          {{else}}
+                            {{moment-format
+                              referrenceFile.scannedDate
+                              "YYYY-MM-DD HH:mm:ss UTC"
+                            }}
+                          {{/if}}
+                        </span>
+                      </div>
+                    {{/if}}
+                  </td>
+                </tr>
+              {{/each}}
+            </tbody>
+          </table>
+        </div>
       {{/if}}
 
+    <div class="toggle-header">
+      <span class="p-action" {{action "toggleShowResults" "showHistoricalWhois"}}>
+        {{fa-icon "project-diagram" fixedWidth=true}}
+        {{#if block._state.loadingWhois}}
+          {{fa-icon icon="spinner-third" spin=true fixedWidth=true}}
+          Loading Whois ...
+        {{else}}
+          Historical Whois Lookups ({{details.historicalWhoIs.length}})
+        {{/if}}
+        {{fa-icon (if showHistoricalWhois "caret-up" "caret-down") fixedWidth=true}}
+      </span>
+    </div>
 
-      <div class='toggle-header'>
-        <span class='p-action' {{action 'toggleShowResults' 'showHistoricalWhois'}}>
-          {{fa-icon 'project-diagram' fixedWidth=true}}
-          {{#if block._state.loadingWhois}}
-            {{fa-icon icon="spinner-third" spin=true fixedWidth=true}} Loading Whois ...
-          {{else}}
-            Historical Whois Lookups ({{details.historicalWhoIs.length}})
-          {{/if}}
-          {{fa-icon (if showHistoricalWhois 'caret-up' 'caret-down') fixedWidth=true}}
-        </span>
-      </div>
-
-      {{#if showHistoricalWhois}}
-        {{#if (gt details.historicalWhoIs.length 0)}}
-          {{#if block.entity.isIP}}
-          <div class='scan-results'>
+    {{#if showHistoricalWhois}}
+      {{#if (gt details.historicalWhoIs.length 0)}}
+        {{#if block.entity.isIP}}
+          <div class="scan-results">
             <table>
               <thead>
                 <tr>
@@ -499,21 +549,21 @@
             {{#each details.historicalWhoIs as |whoisRow index|}}
               <table>
                 <tbody>
-                  <tr {{action 'expandWhoIsRow' index}}>
+                  <tr {{action "expandWhoIsRow" index}}>
                     <td>
                       {{fa-icon
-                        (if (get expandedWhoisMap index) 'caret-up' 'caret-down')
+                        (if (get expandedWhoisMap index) "caret-up" "caret-down")
                         fixedWidth=true
                       }}
                     </td>
                     <td>
-                      <span class='p-key'>{{moment-format
+                      <span class="p-key">{{moment-format
                           whoisRow.last_updated
-                          'YYYY-MM-DD'
+                          "YYYY-MM-DD"
                         }}</span>
                     </td>
                     <td>
-                      <span class='p-value'>
+                      <span class="p-value">
                         {{#if whoisRow.OrgName}}
                           {{whoisRow.OrgName}}
                         {{else}}
@@ -522,7 +572,7 @@
                       </span>
                     </td>
                     <td>
-                      <span class='p-value'>
+                      <span class="p-value">
                         {{#if whoisRow.OrgTechEmail}}
                           {{whoisRow.OrgTechEmail}}
                         {{else}}
@@ -534,16 +584,16 @@
                 </tbody>
               </table>
               {{#if (get expandedWhoisMap index)}}
-                <div class='whois-expanded'>
+                <div class="whois-expanded">
                   {{#each whoIsIpKeys as |ipKey|}}
                     {{#if (get whoisRow ipKey.key)}}
                       <div>
-                        <span class='p-key'>{{ipKey.key}}:</span>
-                        <span class='p-value'>
+                        <span class="p-key">{{ipKey.key}}:</span>
+                        <span class="p-value">
                           {{#if ipKey.isDate}}
                             {{moment-format
                               (get whoisRow ipKey.key)
-                              'YYYY-MM-DD HH:mm:ss UTC'
+                              "YYYY-MM-DD HH:mm:ss UTC"
                               timeZone=timezone
                             }}
                           {{else}}
@@ -558,7 +608,7 @@
             {{/each}}
           </div>
         {{else}}
-          <div class='scan-results'>
+          <div class="scan-results">
             <table>
               <thead>
                 <tr>
@@ -572,21 +622,21 @@
             {{#each details.historicalWhoIs as |whoisRow index|}}
               <table>
                 <tbody>
-                  <tr {{action 'expandWhoIsRow' index}}>
+                  <tr {{action "expandWhoIsRow" index}}>
                     <td>
                       {{fa-icon
-                        (if (get expandedWhoisMap index) 'caret-up' 'caret-down')
+                        (if (get expandedWhoisMap index) "caret-up" "caret-down")
                         fixedWidth=true
                       }}
                     </td>
                     <td>
-                      <span class='p-key'>{{moment-format
+                      <span class="p-key">{{moment-format
                           whoisRow.last_updated
-                          'YYYY-MM-DD'
+                          "YYYY-MM-DD"
                         }}</span>
                     </td>
                     <td>
-                      <span class='p-value'>
+                      <span class="p-value">
                         {{#if whoisRow.Registrar}}
                           {{whoisRow.Registrar}}
                         {{else}}
@@ -595,7 +645,7 @@
                       </span>
                     </td>
                     <td>
-                      <span class='p-value'>
+                      <span class="p-value">
                         {{#if whoisRow.Registrant}}
                           {{whoisRow.Registrant}}
                         {{else}}
@@ -607,16 +657,16 @@
                 </tbody>
               </table>
               {{#if (get expandedWhoisMap index)}}
-                <div class='whois-expanded'>
+                <div class="whois-expanded">
                   {{#each whoIsDomainKeys as |domainKey|}}
                     {{#if (get whoisRow domainKey.key)}}
                       <div>
-                        <span class='p-key'>{{domainKey.key}}:</span>
-                        <span class='p-value'>
+                        <span class="p-key">{{domainKey.key}}:</span>
+                        <span class="p-value">
                           {{#if domainKey.isDate}}
                             {{moment-format
                               (get whoisRow domainKey.key)
-                              'YYYY-MM-DD HH:mm:ss UTC'
+                              "YYYY-MM-DD HH:mm:ss UTC"
                             }}
                           {{else}}
                             {{get whoisRow domainKey.key}}
@@ -630,9 +680,8 @@
             {{/each}}
           </div>
         {{/if}}
-        {{else}}
-          <span>No historical whois information available</span>
-        {{/if}}
+      {{else}}
+        <span>No historical whois information available</span>
       {{/if}}
 
     {{/if}}

--- a/templates/block.hbs
+++ b/templates/block.hbs
@@ -1,20 +1,20 @@
 <div class="d-flex align-items-center justify-content-end copy-btn-container">
   <button
-          class="btn copy-btn p-action"
+    class="btn copy-btn p-action"
     {{action "copyData"}}
-          title="Copy Information to Clipboard"
+    title="Copy Information to Clipboard"
   >
     {{fa-icon icon="clipboard" fixedWidth=true}}
   </button>
   <div class="copy-success-message {{if showCopyMessage 'visible' 'hidden'}}">
     {{fa-icon icon="check" fixedWidth=true class="copy-success-icon"}}
-    {{#if (eq activeTab 'detection')}}
+    {{#if (eq activeTab "detection")}}
       Copied Detection Information.
-    {{else if (eq activeTab 'details')}}
+    {{else if (eq activeTab "details")}}
       Copied Details Information.
-    {{else if (eq activeTab 'relations')}}
+    {{else if (eq activeTab "relations")}}
       Copied Relations Information.
-    {{else if (eq activeTab 'behaviorSummary')}}
+    {{else if (eq activeTab "behaviorSummary")}}
       Copied Behavior Summary Information.
     {{/if}}
   </div>
@@ -144,175 +144,223 @@
       </li>
     {{/if}}
   </ul>
-  <div id="{{concat "virustotal-container-" uniqueIdPrefix}}" class="export-node">
-    {{#if (eq activeTab 'detection')}}
+  <div id="{{concat 'virustotal-container-' uniqueIdPrefix}}" class="export-node">
+    {{#if (eq activeTab "detection")}}
 
-  {{#if (eq activeTab "detection")}}
-    <div class="p-link mt-2">
-      <a href="{{details.detectionsLink}}">View detections in VirusTotal
-        {{fa-icon "external-link-square" class="external-link-icon"}}</a>
-    </div>
-    <h1 class="p-title">{{fa-icon "clipboard" fixedWidth=true}} Summary</h1>
-    <div>
-      <strong>{{details.positiveScans.length}}</strong>
-      security vendor{{#if (not-eq details.positiveScans.length 1)}}s{{/if}}
-      flagged this indicator as malicious. The indicator has a community score of
-      <strong>{{details.reputation}}</strong>
-      and was last scanned
-      <strong>{{moment-from-now details.scan_date timeZone=timezone}}</strong>
-      on
-      {{moment-format details.scan_date "YYYY-MM-DD HH:mm:ss z" timeZone=timezone}}. A
-      negative community score indicates maliciousness, whereas a positive score reflects
-      harmlessness where the higher the absolute number the more you may trust the score
-      (-100 to 100).
-    </div>
-    {{! detections }}
-    <div class="toggle-header">
-      <span class="p-action" {{action "toggleShowResults" "showScanResults"}}>
-        {{fa-icon "laptop" fixedWidth=true}}
-        {{#unless block.userOptions.showNoDetections}}Positive {{/unless}}
-        Detections ({{details.positives}}
-        of
-        {{details.total}})
-        {{fa-icon (if showScanResults "caret-up" "caret-down") fixedWidth=true}}
-      </span>
-    </div>
-    {{#if showScanResults}}
-      <div class="scan-results">
-        {{#unless details.positiveScans}}
-          <span>No security vendor flagged this indicator as malicious</span>
-        {{/unless}}
-        <table>
-          <tbody>
-            {{#each details.positiveScans as |positiveScan|}}
-              <tr>
-                <td>
-                  <span class="p-key">{{positiveScan.name}} </span>
-                </td>
-                <td>
-                  <span class="p-value" style="color: #FF3A59">
-                    {{fa-icon "exclamation" class="p-red table-icon" fixedWidth=true}}
-                    {{positiveScan.result}}
-                  </span>
-                </td>
-              </tr>
-            {{/each}}
-            {{#if block.userOptions.showNoDetections}}
-              {{#each details.negativeScans as |negativeScan|}}
+      <div class="p-link mt-2">
+        <a href="{{details.detectionsLink}}">View detections in VirusTotal
+          {{fa-icon "external-link-square" class="external-link-icon"}}</a>
+      </div>
+      <h1 class="p-title">{{fa-icon "clipboard" fixedWidth=true}} Summary</h1>
+      <div>
+        <strong>{{details.positiveScans.length}}</strong>
+        security vendor{{#if (not-eq details.positiveScans.length 1)}}s{{/if}}
+        flagged this indicator as malicious. The indicator has a community score of
+        <strong>{{details.reputation}}</strong>
+        and was last scanned
+        <strong>{{moment-from-now details.scan_date timeZone=timezone}}</strong>
+        on
+        {{moment-format details.scan_date "YYYY-MM-DD HH:mm:ss z" timeZone=timezone}}. A
+        negative community score indicates maliciousness, whereas a positive score
+        reflects harmlessness where the higher the absolute number the more you may trust
+        the score (-100 to 100).
+      </div>
+      {{! detections }}
+      <div class="toggle-header">
+        <span class="p-action" {{action "toggleShowResults" "showScanResults"}}>
+          {{fa-icon "laptop" fixedWidth=true}}
+          {{#unless block.userOptions.showNoDetections}}Positive {{/unless}}
+          Detections ({{details.positives}}
+          of
+          {{details.total}})
+          {{fa-icon (if showScanResults "caret-up" "caret-down") fixedWidth=true}}
+        </span>
+      </div>
+      {{#if showScanResults}}
+        <div class="scan-results">
+          {{#unless details.positiveScans}}
+            <span>No security vendor flagged this indicator as malicious</span>
+          {{/unless}}
+          <table>
+            <tbody>
+              {{#each details.positiveScans as |positiveScan|}}
                 <tr>
                   <td>
-                    <span class="p-key">{{negativeScan.name}} </span>
+                    <span class="p-key">{{positiveScan.name}} </span>
                   </td>
                   <td>
-                    <span class="p-value">
-                      {{#if (eq negativeScan.result "Unrated")}}
-                        {{fa-icon "question" class="p-grey table-icon" fixedWidth=true}}
-                      {{else}}
-                        {{#if (eq negativeScan.result "type-unsupported")}}
-                          {{fa-icon
-                            "eye-slash"
-                            class="p-grey table-icon"
-                            fixedWidth=true
-                          }}
+                    <span class="p-value" style="color: #FF3A59">
+                      {{fa-icon "exclamation" class="p-red table-icon" fixedWidth=true}}
+                      {{positiveScan.result}}
+                    </span>
+                  </td>
+                </tr>
+              {{/each}}
+              {{#if block.userOptions.showNoDetections}}
+                {{#each details.negativeScans as |negativeScan|}}
+                  <tr>
+                    <td>
+                      <span class="p-key">{{negativeScan.name}} </span>
+                    </td>
+                    <td>
+                      <span class="p-value">
+                        {{#if (eq negativeScan.result "Unrated")}}
+                          {{fa-icon "question" class="p-grey table-icon" fixedWidth=true}}
                         {{else}}
-                          {{#if (eq negativeScan.result "Suspicious")}}
-                            {{fa-icon "info" class="p-orange table-icon" fixedWidth=true}}
+                          {{#if (eq negativeScan.result "type-unsupported")}}
+                            {{fa-icon
+                              "eye-slash"
+                              class="p-grey table-icon"
+                              fixedWidth=true
+                            }}
                           {{else}}
-                            {{fa-icon "check" class="p-green table-icon" fixedWidth=true}}
-                          {{/if}}
-                        {{/if}}
-                      {{/if}}
-                      {{#if (eq negativeScan.result "type-unsupported")}}
-                        <span class="p-grey">Unable to process file type</span>
-                      {{else}}
-                        {{#if (eq negativeScan.result "Suspicious")}}
-                          <span class="p-orange">Suspicious</span>
-                        {{else}}
-                          {{#if (not negativeScan.result)}}
-                            Undetected
-                          {{else}}
-                            {{#if (eq negativeScan.result 'Suspicious')}}
-                              <span class='p-orange'>Suspicious</span>
+                            {{#if (eq negativeScan.result "Suspicious")}}
+                              {{fa-icon
+                                "info"
+                                class="p-orange table-icon"
+                                fixedWidth=true
+                              }}
                             {{else}}
-                              {{#if (not negativeScan.result)}}
-                                Undetected
-                              {{else}}
-                                {{negativeScan.result}}
-                              {{/if}}
+                              {{fa-icon
+                                "check"
+                                class="p-green table-icon"
+                                fixedWidth=true
+                              }}
                             {{/if}}
                           {{/if}}
-                        </span>
-                      </td>
-                    </tr>
-                  {{/each}}
-                {{/if}}
-              </tbody>
-            </table>
-          </div>
-        {{/if}}
+                        {{/if}}
+                        {{#if (eq negativeScan.result "type-unsupported")}}
+                          <span class="p-grey">Unable to process file type</span>
+                        {{else}}
+                          {{#if (eq negativeScan.result "Suspicious")}}
+                            <span class="p-orange">Suspicious</span>
+                          {{else}}
+                            {{#if (not negativeScan.result)}}
+                              Undetected
+                            {{else}}
+                              {{negativeScan.result}}
+                            {{/if}}
+                          {{/if}}
+                        {{/if}}
+                      </span>
+                    </td>
+                  </tr>
+                {{/each}}
+              {{/if}}
+            </tbody>
+          </table>
+        </div>
+      {{/if}}
     {{/if}}
     {{! end of detections}}
 
-  {{#if (eq activeTab "details")}}
-    <div class="p-link mt-2">
-      <a href="{{details.detailsLink}}">View Details in VirusTotal
-        {{fa-icon "external-link-square" class="external-link-icon"}}</a>
-    </div>
-    <div class="p-link mt-2">
-      <a href="{{details.communityLink}}">View Comments in VirusTotal
-        {{fa-icon "external-link-square" class="external-link-icon"}}</a>
-    </div>
-    {{#if details.detailsTab.length}}
-      {{#each details.detailsTab as |detailsField|}}
-        {{#if detailsField.isObject}}
-          <h1 class="p-title">{{fa-icon icon="th-list" fixedWidth=true}}
-            {{detailsField.key}}</h1>
-          {{#each-in detailsField.value as |key value|}}
-            {{#if value}}
-              <div>
-                <span class="p-key">{{key}}:</span>
-                <span class="p-value">{{value}}</span>
-              </div>
-            {{/if}}
-          {{/each-in}}
-        {{else if detailsField.isList}}
-          {{#each detailsField.value as |value|}}
-            {{#if value}}
-              <div>
-                <span class="p-key">{{detailsField.key}}:</span>
-                <span class="p-value">{{value}}</span>
-              </div>
-            {{/if}}
-          {{/each}}
-        {{else if detailsField.isTitle}}
-          <h1 class="p-title">{{fa-icon icon="th-list" fixedWidth=true}}
-            {{detailsField.key}}</h1>
-        {{else if detailsField.isDate}}
-          <div>
-            <span class="p-key">{{detailsField.key}}:</span>
-            <span class="p-value">{{moment-format
-                (unix detailsField.value)
-                "YYYY-MM-DD HH:mm:ss z"
-                timeZone=timezone
-              }}</span>
-          </div>
-        {{else}}
-          {{#if detailsField.value}}
+    {{#if (eq activeTab "details")}}
+      <div class="p-link mt-2">
+        <a href="{{details.detailsLink}}">View Details in VirusTotal
+          {{fa-icon "external-link-square" class="external-link-icon"}}</a>
+      </div>
+      <div class="p-link mt-2">
+        <a href="{{details.communityLink}}">View Comments in VirusTotal
+          {{fa-icon "external-link-square" class="external-link-icon"}}</a>
+      </div>
+      {{#if details.detailsTab.length}}
+        {{#each details.detailsTab as |detailsField|}}
+          {{#if detailsField.isObject}}
+            <h1 class="p-title">{{fa-icon icon="th-list" fixedWidth=true}}
+              {{detailsField.key}}</h1>
+            {{#each-in detailsField.value as |key value|}}
+              {{#if value}}
+                <div>
+                  <span class="p-key">{{key}}:</span>
+                  <span class="p-value">{{value}}</span>
+                </div>
+              {{/if}}
+            {{/each-in}}
+          {{else if detailsField.isList}}
+            {{#each detailsField.value as |value|}}
+              {{#if value}}
+                <div>
+                  <span class="p-key">{{detailsField.key}}:</span>
+                  <span class="p-value">{{value}}</span>
+                </div>
+              {{/if}}
+            {{/each}}
+          {{else if detailsField.isTitle}}
+            <h1 class="p-title">{{fa-icon icon="th-list" fixedWidth=true}}
+              {{detailsField.key}}</h1>
+          {{else if detailsField.isDate}}
             <div>
               <span class="p-key">{{detailsField.key}}:</span>
-              <span class="p-value">{{detailsField.value}}</span>
+              <span class="p-value">{{moment-format
+                  (unix detailsField.value)
+                  "YYYY-MM-DD HH:mm:ss z"
+                  timeZone=timezone
+                }}</span>
             </div>
+          {{else}}
+            {{#if detailsField.value}}
+              <div>
+                <span class="p-key">{{detailsField.key}}:</span>
+                <span class="p-value">{{detailsField.value}}</span>
+              </div>
+            {{/if}}
+          {{/if}}
+        {{/each}}
+      {{/if}}
+
+      {{#if (or block.entity.isMD5 block.entity.isSHA1 block.entity.isSHA256)}}
+        <div class="toggle-header">
+          <span class="p-action" {{action "toggleShowResults" "block._state.showNames"}}>
+            {{fa-icon icon="file" fixedWidth=true}}
+            Names ({{details.names.length}})
+            {{fa-icon (if showFilesReferring "caret-up" "caret-down") fixedWidth=true}}
+          </span>
+        </div>
+        {{#if block._state.showNames}}
+          {{#if (gt details.names.length 0)}}
+            <div class="scrollable-block">
+              <table>
+                <tbody>
+                  {{#each details.names as |name index|}}
+                    <tr><td>{{name}}</td></tr>
+                  {{/each}}
+                </tbody>
+              </table>
+            </div>
+          {{else}}
+            <span>No Filenames found</span>
           {{/if}}
         {{/if}}
       {{/if}}
     {{/if}}
 
-    {{#if (or block.entity.isMD5 block.entity.isSHA1 block.entity.isSHA256)}}
+    {{! start of behavior summary}}
+    {{#if (eq activeTab "behaviorSummary")}}
+      <div class="p-link mt-2">
+        <a href="{{details.behaviorLink}}">View behaviors in VirusTotal
+          {{fa-icon "external-link-square" class="external-link-icon"}}</a>
+      </div>
+
+      {{#if block._state.errorBehaviors}}
+        <div class="alert alert-danger mt-2">
+          <pre>{{block._state.errorBehaviors}}</pre>
+        </div>`
+      {{/if}}
+
       <div class="toggle-header">
-        <span class="p-action" {{action "toggleShowResults" "block._state.showNames"}}>
-          {{fa-icon icon="file" fixedWidth=true}}
-          Names ({{details.names.length}})
-          {{fa-icon (if showFilesReferring "caret-up" "caret-down") fixedWidth=true}}
+        <span class="p-action" {{action "toggleShowResults" "showRegistryKeys"}}>
+          {{fa-icon "key" fixedWidth=true}}
+          {{#if block._state.loadingBehaviors}}
+            {{fa-icon icon="spinner-third" spin=true fixedWidth=true}}
+            Loading registry keys ...
+          {{else}}
+            Registry Keys ({{if
+              details.behaviorSummary.registry_keys_opened
+              details.behaviorSummary.registry_keys_opened.length
+              "0"
+            }})
+          {{/if}}
+          {{fa-icon (if showRegistryKeys "caret-up" "caret-down") fixedWidth=true}}
         </span>
       </div>
 
@@ -331,357 +379,301 @@
           <span>No registry key information available</span>
         {{/if}}
       {{/if}}
-    {{/if}}
-  {{/if}}
 
-  {{! start of behavior summary}}
-  {{#if (eq activeTab "behaviorSummary")}}
-
-    <div class="p-link mt-2">
-      <a href="{{details.behaviorLink}}">View behaviors in VirusTotal
-        {{fa-icon "external-link-square" class="external-link-icon"}}</a>
-    </div>
-
-    {{#if block._state.errorBehaviors}}
-      <div class="alert alert-danger mt-2">
-        <pre>{{block._state.errorBehaviors}}</pre>
-      </div>`
-    {{/if}}
-
-    <div class="toggle-header">
-      <span class="p-action" {{action "toggleShowResults" "showRegistryKeys"}}>
-        {{fa-icon "key" fixedWidth=true}}
-        {{#if block._state.loadingBehaviors}}
-          {{fa-icon icon="spinner-third" spin=true fixedWidth=true}}
-          Loading registry keys ...
-        {{else}}
-          Registry Keys ({{if
-            details.behaviorSummary.registry_keys_opened
-            details.behaviorSummary.registry_keys_opened.length
-            "0"
-          }})
-        {{/if}}
-        {{fa-icon (if showRegistryKeys "caret-up" "caret-down") fixedWidth=true}}
-      </span>
-    </div>
+      <div class="toggle-header">
+        <span class="p-action" {{action "toggleShowResults" "showFilesOpened"}}>
+          {{fa-icon "file" fixedWidth=true}}
+          {{#if block._state.loadingBehaviors}}
+            {{fa-icon icon="spinner-third" spin=true fixedWidth=true}}
+            Loading opened files ...
+          {{else}}
+            Opened Files ({{if
+              details.behaviorSummary.files_opened
+              details.behaviorSummary.files_opened.length
+              "0"
+            }})
+          {{/if}}
+          {{fa-icon (if showFilesOpened "caret-up" "caret-down") fixedWidth=true}}
+        </span>
+      </div>
 
       {{#if showFilesOpened}}
         {{#if details.behaviorSummary.files_opened}}
           <div class="scrollable-block">
             <table>
               <tbody>
-              {{#each details.behaviorSummary.files_opened as |file|}}
-                <tr><td>{{file}}</td></tr>
-              {{/each}}
-            </tbody>
-          </table>
-        </div>
-      {{else}}
-        <span>No registry key information available</span>
-      {{/if}}
-    {{/if}}
-
-    <div class="toggle-header">
-      <span class="p-action" {{action "toggleShowResults" "showFilesOpened"}}>
-        {{fa-icon "file" fixedWidth=true}}
-        {{#if block._state.loadingBehaviors}}
-          {{fa-icon icon="spinner-third" spin=true fixedWidth=true}}
-          Loading opened files ...
+                {{#each details.behaviorSummary.files_opened as |file|}}
+                  <tr><td>{{file}}</td></tr>
+                {{/each}}
+              </tbody>
+            </table>
+          </div>
         {{else}}
-          Opened Files ({{if
-            details.behaviorSummary.files_opened
-            details.behaviorSummary.files_opened.length
-            "0"
-          }})
+          <span>No opened files information available</span>
         {{/if}}
-        {{fa-icon (if showFilesOpened "caret-up" "caret-down") fixedWidth=true}}
-      </span>
-    </div>
-
-    {{#if showFilesOpened}}
-      {{#if details.behaviorSummary.files_opened}}
-        <div class="scrollable-block">
-          <table>
-            <tbody>
-              {{#each details.behaviorSummary.files_opened as |file|}}
-                <tr><td>{{file}}</td></tr>
-              {{/each}}
-            </tbody>
-          </table>
-        </div>
-      {{else}}
-        <span>No opened files information available</span>
       {{/if}}
-    {{/if}}
-  {{/if}}
-  {{! end of behavior summary}}
 
-  {{! START RELATIONS TAB }}
-  {{#if (eq activeTab "relations")}}
-    <div class="p-link mt-2">
-      <a href="{{details.relationsLink}}">View relations in VirusTotal
-        {{fa-icon "external-link-square" class="external-link-icon"}}</a>
-    </div>
-
-    {{#if block._state.errorWhois}}
-      <div class="alert alert-danger mt-2">
-        <pre>{{block._state.errorWhois}}</pre>
-      </div>`
     {{/if}}
     {{! end of behavior summary}}
 
+    {{! START RELATIONS TAB }}
+    {{#if (eq activeTab "relations")}}
+      <div class="p-link mt-2">
+        <a href="{{details.relationsLink}}">View relations in VirusTotal
+          {{fa-icon "external-link-square" class="external-link-icon"}}</a>
+      </div>
 
-    <div class="toggle-header">
-      <span class="p-action" {{action "toggleShowResults" "showFilesReferring"}}>
-        {{fa-icon "project-diagram" fixedWidth=true}}
-        {{#if block._state.loadingRelations}}
-          {{fa-icon icon="spinner-third" spin=true fixedWidth=true}}
-          Loading files referring ...
-        {{else}}
-          Files Referring ({{details.referenceFiles.length}})
-        {{/if}}
-        {{fa-icon (if showFilesReferring "caret-up" "caret-down") fixedWidth=true}}
-      </span>
-    </div>
-
-    {{#if showFilesReferring}}
-      {{#if (eq details.referenceFiles.length 0)}}
-        <span>No files referring available</span>
-      {{else}}
-        <button
-          type="button"
-          title="Copy referring file names"
-          class="btn-sm naked file-copy-button"
-          {{action "copyReferringFiles"}}
-        >
-          {{fa-icon
-            icon="copy"
-            fixedWidth=true
-            class="copy-button-icon"
-            title="Copy referring file names"
-          }}
-        </button>
-
-        <div class="scrollable-block">
-          <table>
-            <tbody>
-              {{#each details.referenceFiles as |referrenceFile|}}
-                <tr>
-                  <td class="pr-3">
-                    {{#if referrenceFile.name}}
-                      <div>
-                        <span class="p-key">Name:</span>
-                        <span class="p-value">
-                          {{#if referrenceFile.link}}
-                            <a href={{referrenceFile.link}}>{{referrenceFile.name}}
-                              {{fa-icon
-                                "external-link-square"
-                                class="external-link-icon"
-                              }}</a>
-                          {{else}}
-                            {{referrenceFile.name}}
-                          {{/if}}
-                        </span>
-                      </div>
-                    {{/if}}
-                    {{#if referrenceFile.type}}
-                      <div>
-                        <span class="p-key">Type:</span>
-                        <span class="p-value">{{referrenceFile.type}}</span>
-                      </div>
-                    {{/if}}
-                    {{#if referrenceFile.detections}}
-                      <div>
-                        <span class="p-key">Detections:</span>
-                        <span class="p-value">{{referrenceFile.detections}}</span>
-                      </div>
-                    {{/if}}
-                    {{#if referrenceFile.scannedDate}}
-                      <div>
-                        <span class="p-key">Scanned:</span>
-                        <span class="p-value">
-                          {{#if (eq referrenceFile.scannedDate "-")}}
-                            -
-                          {{else}}
-                            {{moment-format
-                              referrenceFile.scannedDate
-                              "YYYY-MM-DD HH:mm:ss UTC"
-                            }}
-                          {{/if}}
-                        </span>
-                      </div>
-                    {{/if}}
-                  </td>
-                </tr>
-              {{/each}}
-            </tbody>
-          </table>
-        </div>
+      {{#if block._state.errorWhois}}
+        <div class="alert alert-danger mt-2">
+          <pre>{{block._state.errorWhois}}</pre>
+        </div>`
       {{/if}}
 
-    <div class="toggle-header">
-      <span class="p-action" {{action "toggleShowResults" "showHistoricalWhois"}}>
-        {{fa-icon "project-diagram" fixedWidth=true}}
-        {{#if block._state.loadingWhois}}
-          {{fa-icon icon="spinner-third" spin=true fixedWidth=true}}
-          Loading Whois ...
-        {{else}}
-          Historical Whois Lookups ({{details.historicalWhoIs.length}})
-        {{/if}}
-        {{fa-icon (if showHistoricalWhois "caret-up" "caret-down") fixedWidth=true}}
-      </span>
-    </div>
+      {{#if block._state.errorRelations}}
+        <div class="alert alert-danger mt-2">
+          <pre>{{block._state.errorRelations}}</pre>
+        </div>`
+      {{/if}}
 
-    {{#if showHistoricalWhois}}
-      {{#if (gt details.historicalWhoIs.length 0)}}
-        {{#if block.entity.isIP}}
-          <div class="scan-results">
-            <table>
-              <thead>
-                <tr>
-                  <th></th>
-                  <th>Last Updated</th>
-                  <th>Organization</th>
-                  <th>Email</th>
-                </tr>
-              </thead>
-            </table>
-            {{#each details.historicalWhoIs as |whoisRow index|}}
-              <table>
-                <tbody>
-                  <tr {{action "expandWhoIsRow" index}}>
-                    <td>
-                      {{fa-icon
-                        (if (get expandedWhoisMap index) "caret-up" "caret-down")
-                        fixedWidth=true
-                      }}
-                    </td>
-                    <td>
-                      <span class="p-key">{{moment-format
-                          whoisRow.last_updated
-                          "YYYY-MM-DD"
-                        }}</span>
-                    </td>
-                    <td>
-                      <span class="p-value">
-                        {{#if whoisRow.OrgName}}
-                          {{whoisRow.OrgName}}
-                        {{else}}
-                          -
-                        {{/if}}
-                      </span>
-                    </td>
-                    <td>
-                      <span class="p-value">
-                        {{#if whoisRow.OrgTechEmail}}
-                          {{whoisRow.OrgTechEmail}}
-                        {{else}}
-                          -
-                        {{/if}}
-                      </span>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-              {{#if (get expandedWhoisMap index)}}
-                <div class="whois-expanded">
-                  {{#each whoIsIpKeys as |ipKey|}}
-                    {{#if (get whoisRow ipKey.key)}}
-                      <div>
-                        <span class="p-key">{{ipKey.key}}:</span>
-                        <span class="p-value">
-                          {{#if ipKey.isDate}}
-                            {{moment-format
-                              (get whoisRow ipKey.key)
-                              "YYYY-MM-DD HH:mm:ss UTC"
-                              timeZone=timezone
-                            }}
-                          {{else}}
-                            {{get whoisRow ipKey.key}}
-                          {{/if}}
-                        </span>
-                      </div>
-                    {{/if}}
-                  {{/each}}
-                </div>
-              {{/if}}
-            {{/each}}
-          </div>
+      <div class="toggle-header">
+        <span class="p-action" {{action "toggleShowResults" "showFilesReferring"}}>
+          {{fa-icon "project-diagram" fixedWidth=true}}
+          {{#if block._state.loadingRelations}}
+            {{fa-icon icon="spinner-third" spin=true fixedWidth=true}}
+            Loading files referring ...
+          {{else}}
+            Files Referring ({{details.referenceFiles.length}})
+          {{/if}}
+          {{fa-icon (if showFilesReferring "caret-up" "caret-down") fixedWidth=true}}
+        </span>
+      </div>
+
+      {{#if showFilesReferring}}
+        {{#if (eq details.referenceFiles.length 0)}}
+          <span>No files referring available</span>
         {{else}}
-          <div class="scan-results">
+          <div class="scrollable-block">
             <table>
-              <thead>
-                <tr>
-                  <th></th>
-                  <th>Last Updated</th>
-                  <th>Registrar</th>
-                  <th>Registrant</th>
-                </tr>
-              </thead>
-            </table>
-            {{#each details.historicalWhoIs as |whoisRow index|}}
-              <table>
-                <tbody>
-                  <tr {{action "expandWhoIsRow" index}}>
-                    <td>
-                      {{fa-icon
-                        (if (get expandedWhoisMap index) "caret-up" "caret-down")
-                        fixedWidth=true
-                      }}
-                    </td>
-                    <td>
-                      <span class="p-key">{{moment-format
-                          whoisRow.last_updated
-                          "YYYY-MM-DD"
-                        }}</span>
-                    </td>
-                    <td>
-                      <span class="p-value">
-                        {{#if whoisRow.Registrar}}
-                          {{whoisRow.Registrar}}
-                        {{else}}
-                          -
-                        {{/if}}
-                      </span>
-                    </td>
-                    <td>
-                      <span class="p-value">
-                        {{#if whoisRow.Registrant}}
-                          {{whoisRow.Registrant}}
-                        {{else}}
-                          -
-                        {{/if}}
-                      </span>
+              <tbody>
+                {{#each details.referenceFiles as |referrenceFile|}}
+                  <tr>
+                    <td class="pr-3">
+                      {{#if referrenceFile.name}}
+                        <div>
+                          <span class="p-key">Name:</span>
+                          <span class="p-value">
+                            {{#if referrenceFile.link}}
+                              <a href={{referrenceFile.link}}>{{referrenceFile.name}}
+                                {{fa-icon
+                                  "external-link-square"
+                                  class="external-link-icon"
+                                }}</a>
+                            {{else}}
+                              {{referrenceFile.name}}
+                            {{/if}}
+                          </span>
+                        </div>
+                      {{/if}}
+                      {{#if referrenceFile.type}}
+                        <div>
+                          <span class="p-key">Type:</span>
+                          <span class="p-value">{{referrenceFile.type}}</span>
+                        </div>
+                      {{/if}}
+                      {{#if referrenceFile.detections}}
+                        <div>
+                          <span class="p-key">Detections:</span>
+                          <span class="p-value">{{referrenceFile.detections}}</span>
+                        </div>
+                      {{/if}}
+                      {{#if referrenceFile.scannedDate}}
+                        <div>
+                          <span class="p-key">Scanned:</span>
+                          <span class="p-value">
+                            {{#if (eq referrenceFile.scannedDate "-")}}
+                              -
+                            {{else}}
+                              {{moment-format
+                                referrenceFile.scannedDate
+                                "YYYY-MM-DD HH:mm:ss UTC"
+                              }}
+                            {{/if}}
+                          </span>
+                        </div>
+                      {{/if}}
                     </td>
                   </tr>
-                </tbody>
-              </table>
-              {{#if (get expandedWhoisMap index)}}
-                <div class="whois-expanded">
-                  {{#each whoIsDomainKeys as |domainKey|}}
-                    {{#if (get whoisRow domainKey.key)}}
-                      <div>
-                        <span class="p-key">{{domainKey.key}}:</span>
-                        <span class="p-value">
-                          {{#if domainKey.isDate}}
-                            {{moment-format
-                              (get whoisRow domainKey.key)
-                              "YYYY-MM-DD HH:mm:ss UTC"
-                            }}
-                          {{else}}
-                            {{get whoisRow domainKey.key}}
-                          {{/if}}
-                        </span>
-                      </div>
-                    {{/if}}
-                  {{/each}}
-                </div>
-              {{/if}}
-            {{/each}}
+                {{/each}}
+              </tbody>
+            </table>
           </div>
         {{/if}}
-      {{else}}
-        <span>No historical whois information available</span>
+      {{/if}}
+
+      <div class="toggle-header">
+        <span class="p-action" {{action "toggleShowResults" "showHistoricalWhois"}}>
+          {{fa-icon "project-diagram" fixedWidth=true}}
+          {{#if block._state.loadingWhois}}
+            {{fa-icon icon="spinner-third" spin=true fixedWidth=true}}
+            Loading Whois ...
+          {{else}}
+            Historical Whois Lookups ({{details.historicalWhoIs.length}})
+          {{/if}}
+          {{fa-icon (if showHistoricalWhois "caret-up" "caret-down") fixedWidth=true}}
+        </span>
+      </div>
+
+      {{#if showHistoricalWhois}}
+        {{#if (gt details.historicalWhoIs.length 0)}}
+          {{#if block.entity.isIP}}
+            <div class="scan-results">
+              <table>
+                <thead>
+                  <tr>
+                    <th></th>
+                    <th>Last Updated</th>
+                    <th>Organization</th>
+                    <th>Email</th>
+                  </tr>
+                </thead>
+              </table>
+              {{#each details.historicalWhoIs as |whoisRow index|}}
+                <table>
+                  <tbody>
+                    <tr {{action "expandWhoIsRow" index}}>
+                      <td>
+                        {{fa-icon
+                          (if (get expandedWhoisMap index) "caret-up" "caret-down")
+                          fixedWidth=true
+                        }}
+                      </td>
+                      <td>
+                        <span class="p-key">{{moment-format
+                            whoisRow.last_updated
+                            "YYYY-MM-DD"
+                          }}</span>
+                      </td>
+                      <td>
+                        <span class="p-value">
+                          {{#if whoisRow.OrgName}}
+                            {{whoisRow.OrgName}}
+                          {{else}}
+                            -
+                          {{/if}}
+                        </span>
+                      </td>
+                      <td>
+                        <span class="p-value">
+                          {{#if whoisRow.OrgTechEmail}}
+                            {{whoisRow.OrgTechEmail}}
+                          {{else}}
+                            -
+                          {{/if}}
+                        </span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                {{#if (get expandedWhoisMap index)}}
+                  <div class="whois-expanded">
+                    {{#each whoIsIpKeys as |ipKey|}}
+                      {{#if (get whoisRow ipKey.key)}}
+                        <div>
+                          <span class="p-key">{{ipKey.key}}:</span>
+                          <span class="p-value">
+                            {{#if ipKey.isDate}}
+                              {{moment-format
+                                (get whoisRow ipKey.key)
+                                "YYYY-MM-DD HH:mm:ss UTC"
+                                timeZone=timezone
+                              }}
+                            {{else}}
+                              {{get whoisRow ipKey.key}}
+                            {{/if}}
+                          </span>
+                        </div>
+                      {{/if}}
+                    {{/each}}
+                  </div>
+                {{/if}}
+              {{/each}}
+            </div>
+          {{else}}
+            <div class="scan-results">
+              <table>
+                <thead>
+                  <tr>
+                    <th></th>
+                    <th>Last Updated</th>
+                    <th>Registrar</th>
+                    <th>Registrant</th>
+                  </tr>
+                </thead>
+              </table>
+              {{#each details.historicalWhoIs as |whoisRow index|}}
+                <table>
+                  <tbody>
+                    <tr {{action "expandWhoIsRow" index}}>
+                      <td>
+                        {{fa-icon
+                          (if (get expandedWhoisMap index) "caret-up" "caret-down")
+                          fixedWidth=true
+                        }}
+                      </td>
+                      <td>
+                        <span class="p-key">{{moment-format
+                            whoisRow.last_updated
+                            "YYYY-MM-DD"
+                          }}</span>
+                      </td>
+                      <td>
+                        <span class="p-value">
+                          {{#if whoisRow.Registrar}}
+                            {{whoisRow.Registrar}}
+                          {{else}}
+                            -
+                          {{/if}}
+                        </span>
+                      </td>
+                      <td>
+                        <span class="p-value">
+                          {{#if whoisRow.Registrant}}
+                            {{whoisRow.Registrant}}
+                          {{else}}
+                            -
+                          {{/if}}
+                        </span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                {{#if (get expandedWhoisMap index)}}
+                  <div class="whois-expanded">
+                    {{#each whoIsDomainKeys as |domainKey|}}
+                      {{#if (get whoisRow domainKey.key)}}
+                        <div>
+                          <span class="p-key">{{domainKey.key}}:</span>
+                          <span class="p-value">
+                            {{#if domainKey.isDate}}
+                              {{moment-format
+                                (get whoisRow domainKey.key)
+                                "YYYY-MM-DD HH:mm:ss UTC"
+                              }}
+                            {{else}}
+                              {{get whoisRow domainKey.key}}
+                            {{/if}}
+                          </span>
+                        </div>
+                      {{/if}}
+                    {{/each}}
+                  </div>
+                {{/if}}
+              {{/each}}
+            </div>
+          {{/if}}
+        {{else}}
+          <span>No historical whois information available</span>
+        {{/if}}
       {{/if}}
 
     {{/if}}


### PR DESCRIPTION
Here are some entities that return data for behavior summary and some that don't. If the searched returned data, the integration would operate as expected, if it was an entity that did not have data, the API endpoint would return `null` causing the integration to crash. 

Didn't crash integration: 
34FB450417471EBA939057E903B25523
31443B7329B1BDBCF0564E68406BEABF2A30168FDCB7042BCA8FB2998E3F11C5


crashed integration
FD904ADDBDFE548C22FFA5223ED9EEE7
45430FEC6BDFC406866088097E80E10AE57E16962B535B917CD574C50408A425